### PR TITLE
[App-139]: update GitHub Actions CI security status badges links to follow new Organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Production:
 ### Security Status:
-![Staging GHA CI status badge placeholder](https://github.com/WTA-Stats/application/actions/workflows/testing.yml/badge.svg?branch=main) ![Staging GHA CI status badge placeholder](https://github.com/WTA-Stats/application/actions/workflows/dependency_vulnerabilities.yml/badge.svg?branch=main) ![Staging GHA CI status badge placeholder](https://github.com/WTA-Stats/application/actions/workflows/static_analysis_security_vulnerabilities.yml/badge.svg?branch=main)
+![Staging GHA CI status badge placeholder](https://github.com/wta-fourty-love/application/actions/workflows/testing.yml/badge.svg?branch=main) ![Staging GHA CI status badge placeholder](https://github.com/wta-fourty-love/application/actions/workflows/dependency_vulnerabilities.yml/badge.svg?branch=main) ![Staging GHA CI status badge placeholder](https://github.com/wta-fourty-love/application/actions/workflows/static_analysis_security_vulnerabilities.yml/badge.svg?branch=main)
 
 # Staging:
 ### Security Status:
-![Staging GHA CI status badge placeholder](https://github.com/WTA-Stats/application/actions/workflows/testing.yml/badge.svg?branch=staging) ![Staging GHA CI status badge placeholder](https://github.com/WTA-Stats/application/actions/workflows/dependency_vulnerabilities.yml/badge.svg?branch=staging) ![Staging GHA CI status badge placeholder](https://github.com/WTA-Stats/application/actions/workflows/static_analysis_security_vulnerabilities.yml/badge.svg?branch=staging)
+![Staging GHA CI status badge placeholder](https://github.com/wta-fourty-love/application/actions/workflows/testing.yml/badge.svg?branch=staging) ![Staging GHA CI status badge placeholder](https://github.com/wta-fourty-love/application/actions/workflows/dependency_vulnerabilities.yml/badge.svg?branch=staging) ![Staging GHA CI status badge placeholder](https://github.com/wta-fourty-love/application/actions/workflows/static_analysis_security_vulnerabilities.yml/badge.svg?branch=staging)


### PR DESCRIPTION
update GitHub Actions CI security status badges links to follow new Organization name