### PR TITLE
[App-176]: update GHA workflow for Allowed Dependency Licensing to run on ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/allowed_dependency_licensing.yml
+++ b/.github/workflows/allowed_dependency_licensing.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   LicenseFinder:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
update GHA workflow for Allowed Dependency Licensing to run on ubuntu-latest instead of ubuntu-18.04