### PR TITLE
[App-177]: update GHA workflow for Dependency Vulnerabilities to run on ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/dependency_vulnerabilities.yml
+++ b/.github/workflows/dependency_vulnerabilities.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   BundlerAudit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
update GHA workflow for Dependency Vulnerabilities to run on ubuntu-latest instead of ubuntu-18.04