### PR TITLE
[App-178]: update GHA workflow for Static Analysis Security Vulnerabilities to run on ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/static_analysis_security_vulnerabilities.yml
+++ b/.github/workflows/static_analysis_security_vulnerabilities.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   Brakeman:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
update GHA workflow for Static Analysis Security Vulnerabilities to run on ubuntu-latest instead of ubuntu-18.04