### PR TITLE
[App-179]: update GHA workflow for Testing to run on ubuntu-latest instead of ubuntu-18.04

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   RSpec:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres:12


### PR DESCRIPTION
update GHA workflow for Testing to run on ubuntu-latest instead of ubuntu-18.04