### PR TITLE
[App-185]: remove RSpec configuration default DOC formatter when RSpec has one file to run

### DIFF
--- a/spec/spec_configuration.rb
+++ b/spec/spec_configuration.rb
@@ -17,6 +17,8 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.disable_monkey_patching!
   #config.profile_examples = 10
 
   config.expect_with :rspec do |expectations|
@@ -25,12 +27,6 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
-  end
-
-  config.shared_context_metadata_behavior = :apply_to_host_groups
-  config.disable_monkey_patching!
-  if config.files_to_run.one?
-    config.default_formatter = "doc"
   end
 end
 


### PR DESCRIPTION
remove RSpec configuration default DOC formatter when RSpec has one file to run