### PR TITLE
[App-207]: ignore 'describe', 'context' methods in Metrics/BlockLength RuboCop checks config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ Lint/MissingSuper:
 
 Layout/LineLength:
   Max: 145
+
+Metrics/BlockLength:
+  IgnoredMethods: ['describe', 'context']


### PR DESCRIPTION
ignore 'describe', 'context' methods in Metrics/BlockLength RuboCop checks config