### PR TITLE
[App-225]: define object non exists error in API Controller with status 400, rescue from ::Exceptions::ObjectNonExistsError

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class ApiController < ActionController::Base
+  rescue_from ::Exceptions::ObjectNonExistsError, with: :object_non_exists_error
   rescue_from ::Exceptions::ValidationError, with: :validation_error
+
+  def object_non_exists_error
+    render json: { error: 'object_non_exists' }, status: 400
+  end
 
   def validation_error(exception)
     render json: { error: exception.errors }, status: 422


### PR DESCRIPTION
define object non exists error in API Controller with status 400, rescue from ::Exceptions::ObjectNonExistsError