### PR TITLE
[App-248]: disable Metrics/BlockLength and Metrics/MethodLength Cops for Database migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,9 @@ Layout/LineLength:
 
 Metrics/BlockLength:
   IgnoredMethods: ['describe', 'context']
+  Exclude:
+    - 'db/migrate/*'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'db/migrate/*'


### PR DESCRIPTION
[App-248]: disable Metrics/BlockLength and Metrics/MethodLength Cops for Database migrations