### PR TITLE
[App-259]: use Sentry::Rack::CaptureExceptions in Rackup config file to alert Rack exceptions to Sentry

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -5,4 +5,6 @@
 require_relative 'config/environment'
 
 run Rails.application
+use Sentry::Rack::CaptureExceptions
+
 Rails.application.load_server


### PR DESCRIPTION
use Sentry::Rack::CaptureExceptions in Rackup config file to alert Rack exceptions to Sentry